### PR TITLE
Add CHECK-TYPE assertions to convenience send functions.

### DIFF
--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -95,12 +95,14 @@
 ;;
 (defun send-text-message (client message)
   "MESSAGE is a string"
+  (check-type message string)
   (send-frame client +text-frame+
               (flexi-streams:string-to-octets message
                                               :external-format :utf-8)))
 
 (defun send-binary-message (client message)
   "MESSAGE is an array of octets"
+  (check-type message (vector (unsigned-byte 8)))
   (send-frame client +binary-frame+
               message))
 


### PR DESCRIPTION
Use a CHECK-TYPE macro to enforce the types specified in the docstrings for SEND-TEXT-MESSAGE and SEND-BINARY-MESSAGE, which will hopefully catch errors before they get too far into the internals of things.

The check for binary messages is a little bit aggressive: on SBCL, #(1 2 3) fails to pass the check, even though it's probably acceptable input for SEND-BINARY-MESSAGE. This shouldn't cause an issue in practice, but if it does the CHECK-TYPE could be replaced with an ASSERT that's more accurate.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/capitaomorte/hunchensocket/7)

<!-- Reviewable:end -->
