### PR TITLE
websocket-ssl-acceptor: provide request/reply-class default-initargs

### DIFF
--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -33,7 +33,9 @@
                      :reply-class 'websocket-reply))
 
 (defclass websocket-ssl-acceptor (websocket-acceptor ssl-acceptor) ()
-  (:documentation "Special WebSocket SSL acceptor"))
+  (:documentation "Special WebSocket SSL acceptor")
+  (:default-initargs :request-class 'websocket-request
+                     :reply-class 'websocket-reply))
 
 (defclass websocket-client ()
   ((input-stream     :initarg input-stream


### PR DESCRIPTION
acceptor-dispatch-request in hunchensocket is specialized on both
acceptor and requst, where the latter must be websocket-request.

websocket-ssl-acceptor does inherit from websocket-acceptor, but it
doesn't set default-initargs for request and reply classes, what leads
to wrong dispatch, where default acceptor-dispatch-request is chosen
instead of websocket one (because it has second argument specialized
on T), what leads to 404 on all ssl connections.