### PR TITLE
Fix socket timeouts under LispWorks

### DIFF
--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -502,7 +502,12 @@ payloads."
                                               :resource resource
                                               :request request)
           ;; HACK! ask upstream Hunchentoot for this.
+          #-lispworks
           (hunchentoot::set-timeouts *websocket-socket* timeout timeout)
+          #+lispworks
+          (setf (stream:stream-read-timeout stream) timeout
+                (stream:stream-write-timeout stream) timeout)
+          
           (catch 'websocket-done
             (handler-bind ((error #'(lambda (e)
                                       (maybe-invoke-debugger e)

--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -501,7 +501,11 @@ payloads."
                                               :output-stream stream
                                               :resource resource
                                               :request request)
-          ;; HACK! ask upstream Hunchentoot for this.
+          ;; See https://github.com/joaotavora/hunchensocket/pull/23
+          ;; LispWorks in Hunchentoot passes around a USOCKET:USOCKET
+          ;; handle, not an actual such object. Unfortunately, abusing
+          ;; Hunchentoot's internals consequently forces us to tend to
+          ;; this LispWorks particularity.
           #-lispworks
           (hunchentoot::set-timeouts *websocket-socket* timeout timeout)
           #+lispworks


### PR DESCRIPTION
With this patch, Hunchensocket seems to work satisfactorily under LispWorks.  Without this patch, the websocket connection is almost immediately terminated, effectively precluding its use.

I looked at patching this behavior in `hunchentoot` itself but it is actually cleaner to do this in `hunchensocket`.  The following paragraph justifies this judgement with a brief explication.

`hunchentoot::set-timeouts` effectively has no implementation under LispWorks in that it has an empty codepath when `lispworks` is present in `*features*`.  Even though `usocket` has an implementation for setting send/receive socket timeouts for LispWorks using FLI, the actual usocket structure passed around in Hunchentoot under LispWorks does not contain a socket to work on, but rather a socket handle, which seems to be a list containing a single integer (a file descriptor), so patching Hunchentoot would require a fairly substantial reworking of how it operates under LispWorks.  