### PR TITLE
Added a generic extension mechanism and support for RFC7692 (permessage-deflate)

### DIFF
--- a/compression.lisp
+++ b/compression.lisp
@@ -1,0 +1,86 @@
+(in-package #:compression)
+
+(defclass persistent-z-stream ()
+  ((operation :initarg :operation
+              :initform (error "Must specify one of (:inflate :deflate)")
+              :reader persistent-op)
+   (z-stream  :initform nil
+              :accessor persistent-stream))
+  (:documentation "Wrapper class for ZLIB-FFI:Z-STREAM. Accessing the
+Zlib z-stream pointer this way allows the foreign memory to be
+automatically freed when objects of this class are garbage
+collected. It also means we don't need to specify the operation we
+want to do (:inflate or :deflate), as this is a property of the
+stream."))
+
+(defmethod initialize-instance :after ((object persistent-z-stream) &key)
+  "Set up the foreign pointer to the zlib stream and take care of
+freeing the foreign memory when the object is garbage-collected."
+  (let* ((op (persistent-op object))
+         (zs (z-stream-open op :suppress-header t :gzip-format nil)))
+    (setf (persistent-stream object) zs)
+    ;; Function to call when the object is garbage collected to
+    ;; release the foreign memory
+    (finalize object (lambda ()
+                       (handler-case
+                           (z-stream-close zs op)
+                         (zlib-error (condition)
+                           ;; According to the Zlib manual, if a Z_DATA_ERROR is
+                           ;; returned when closing a stream, the memory is still
+                           ;; freed, so we can ignore this error.
+                           (if (= +z-data-error+ (errno-of condition))
+                               (values nil condition)
+                               condition)))))))
+
+(defmethod stream-operation ((object persistent-z-stream) source dest input-fn
+                             output-fn buffer-size flush-type)
+  "Reimplementation of DEOXYBYTE-GZIP:Z-STREAM-OPERATION.
+
+Additionally allows specification of zlib flush type, which is needed for
+WebSocket compression extensions."
+  (let ((zs    (persistent-stream object))
+        (op-fn (ecase (persistent-op object)
+                 (:inflate #'%inflate)
+                 (:deflate #'%deflate)))
+        (in-buffer  (make-shareable-byte-vector buffer-size))
+        (out-buffer (make-shareable-byte-vector buffer-size)))
+    (with-foreign-slots ((avail-in next-in
+                          avail-out next-out 
+                          total-in total-out)
+                         zs z-stream)
+           (with-pointer-to-vector-data (in in-buffer)
+             (with-pointer-to-vector-data (out out-buffer)
+               (flet ((read-from-zs ()
+                        (when (zerop avail-in)
+                          (let ((num-read (funcall input-fn in-buffer
+                                                   source buffer-size)))
+                            (declare (type vector-index num-read))
+                            (when (plusp num-read)
+                              (setf next-in in
+                                    avail-in num-read))))
+                        avail-in)
+                      (write-from-zs ()
+                        (let ((fullp (zerop avail-out))
+                              (output-bytes (- buffer-size avail-out)))
+                          (unless (zerop output-bytes)
+                            (funcall output-fn out-buffer dest output-bytes)
+                            (setf next-out out
+                                  avail-out buffer-size))
+                          fullp))) ; Was the output buffer full on writing?
+                 (setf next-out out
+                       avail-out buffer-size)
+                 (loop
+                    for num-read = (read-from-zs)
+                    while (plusp num-read)
+                    do (let ((flush (if (= buffer-size num-read)
+                                        +z-no-flush+
+                                        flush-type)))
+                         (loop
+                            with out-full = t
+                            while out-full
+                            do (let ((x (funcall op-fn zs flush)))
+                                 (when (= +z-stream-error+ x)
+                                   (z-error x))
+                                 (setf out-full (write-from-zs)))))
+                    finally (progn
+                              (return (values total-in total-out))))))))))

--- a/demo.lisp
+++ b/demo.lisp
@@ -21,8 +21,8 @@
 ;; `hunchensocket:*websocket-dispatch-table*` works just like
 ;; `hunchentoot:*dispatch-table*`, but for websocket specific resources.
 
-(defvar *chat-rooms* (list (make-instance 'chat-room :name "/bongo")
-                           (make-instance 'chat-room :name "/fury")))
+(defparameter *chat-rooms* (list (make-instance 'chat-room :name "/bongo")
+                                 (make-instance 'chat-room :name "/fury")))
 
 (defun find-room (request)
   (find (hunchentoot:script-name request) *chat-rooms* :test #'string= :key #'name))
@@ -48,9 +48,11 @@
 ;; just like `hunchentoot:acceptor`, and you can probably also use
 ;; `hunchensocket:websocket-ssl-acceptor`.
 
-(defvar *server* (make-instance 'hunchensocket:websocket-acceptor :port 12345))
+(defparameter *server* (make-instance 'hunchensocket:websocket-acceptor
+                                :port 12346
+                                :extension (make-instance 'hunchensocket::permessage-deflate)))
 
-(unless (hunchentoot::acceptor-listen-socket acceptor) ; should be
+(unless (hunchentoot::acceptor-listen-socket *server*) ; should be
                                                        ; hunchentoot:listening-p
                                                        ; if it existed
   (hunchentoot:start *server*))

--- a/demo.lisp
+++ b/demo.lisp
@@ -49,8 +49,10 @@
 ;; `hunchensocket:websocket-ssl-acceptor`.
 
 (defparameter *server* (make-instance 'hunchensocket:websocket-acceptor
-                                :port 12346
-                                :extension (make-instance 'hunchensocket::permessage-deflate)))
+                                      :port 12347
+                                      :extensions '((:extension hunchensocket::permessage-deflate
+                                                     :headers ("permessage-deflate")
+                                                     :parameters nil))))
 
 (unless (hunchentoot::acceptor-listen-socket *server*) ; should be
                                                        ; hunchentoot:listening-p

--- a/extensions.lisp
+++ b/extensions.lisp
@@ -1,0 +1,135 @@
+;;;; Compression and decompression routines to support the permessage-deflate
+;;;; extension to the WebSockets protocol (RFC 7692).
+;;;; Isaac Stead, October 2020
+
+(in-package #:hunchensocket)
+
+(defclass websocket-extension ()
+  ((headers :initarg :headers :reader extension-headers
+            :documentation "List of necessary headers for the
+            initial handshake needed by the extension")
+   (frame-header-bits :initarg :frame-header-bits :reader extension-frame-data
+                      :documentation "Return the frame header bits
+                      necessary for the protocol extension."))
+  (:documentation "Base class for extensions to the websocket protocol."))
+
+(defgeneric process-send-message (extension message)
+  (:documentation "Process an outgoing message"))
+
+(defgeneric process-receive-message (extension message)
+  (:documentation "Process an incoming message"))
+
+(defun format-headers (headers)
+  "Concatenate extension header strings in the correct format"
+  (str:join "; " headers))
+
+(defclass permessage-deflate (websocket-extension)
+  ()
+  (:default-initargs :headers '("permessage-deflate")
+                     :frame-header-bits #x04))
+
+(defmethod process-send-message ((ext permessage-deflate) message-bytes)
+  (declare (ignore ext))
+  (compress-bytes message-bytes))
+
+(defmethod process-receive-message ((ext permessage-deflate) message-bytes)
+  (declare (ignore ext))
+  (decompress-bytes message-bytes))
+
+(defun compress-bytes (bytes)
+  ;; Normally, Z_SYNC_FLUSH would be used to append an empty deflate
+  ;; block. But according to the spec (7.2.3.4), we can use deflate
+  ;; blocks with the BFINAL bit set to 1, and append 0x00 to allow
+  ;; decompression by the same method as with Z_SYNC_FLUSH output.
+  ;; I'm using this method because I couldn't find a way of getting
+  ;; the Z_SYNC_FLUSH behaviour with any of the CL deflate libraries.
+  (concatenate '(vector (unsigned-byte 8))
+               (salza2:compress-data bytes 'salza2:deflate-compressor)
+               #(#x00)))
+
+(defun decompress-bytes (bytes)
+  ;; If the BFINAL bit in the deflate header is set to 0 the decompression
+  ;; will fail, so set it if necessary
+  (setf (ldb (byte 1 0)
+             (aref bytes 0))
+        #x01)
+  ;; Now do the actual decompression
+  (chipz:decompress nil *dstate*
+                    ;; The decompression method specified in RFC7692
+                    (concatenate '(vector (unsigned-byte 8))
+                                 bytes #(#x00 #x00 #xff #xff))))
+
+;; (defun send-message (resource client message &key (type :text))
+;;   "TODO documentation"
+;;   (let* ((extension     (resource-extension resource))
+;;          (message-bytes (ecase type
+;;                           (:text   (flexi-streams:string-to-octets message :external-format :utf-8))
+;;                           (:binary message)))
+;;          (frame-type    (ecase type
+;;                           (:text +text-frame+)
+;;                           (:binary +binary-frame+)))
+;;          (maybe-processed-message (if extension
+;;                                       (process-send-message extension message-bytes)
+;;                                       message)))
+;;     (with-slots (write-lock output-stream) client
+;;       (with-lock-held (write-lock)
+;;         (write-frame output-stream
+;;                      frame-type
+;;                      maybe-processed-message
+;;                      (if extension
+;;                          (extension-frame-data extension)
+;;                          #x00))))))
+
+(defparameter *z-deflate-stream* (deoxybyte-gzip::z-stream-open :deflate :suppress-header t :gzip-format nil))
+(defparameter *z-inflate-stream* (deoxybyte-gzip::z-stream-open :inflate :suppress-header t :gzip-format nil))
+
+(defun persistent-z-stream-operation (zs operation source dest input-fn output-fn buffer-size)
+  "Like deoxybyte:z-stream-operation, but called on an external
+z-stream so the compression / decompression algorithm state can be
+maintained between messages. Uses Z_SYNC_FLUSH rather than Z_FINISH as in the original function."
+  (let ((op-fn (ecase operation
+                 (:inflate #'zlib-ffi:%inflate)
+                 (:deflate #'zlib-ffi:%deflate)))
+        (in-buffer  (zlib-ffi::make-shareable-byte-vector buffer-size))
+        (out-buffer (zlib-ffi::make-shareable-byte-vector buffer-size)))
+    (unwind-protect
+         (cffi:with-foreign-slots ((zlib-ffi::avail-in zlib-ffi::next-in
+                                    zlib-ffi::avail-out zlib-ffi::next-out 
+                                    zlib-ffi::total-in zlib-ffi::total-out)
+                                   zs zlib-ffi::z-stream)
+           (cffi:with-pointer-to-vector-data (in in-buffer)
+             (cffi:with-pointer-to-vector-data (out out-buffer)
+               (flet ((read-from-zs ()
+                        (when (zerop zlib-ffi::avail-in)
+                          (let ((num-read (funcall input-fn in-buffer
+                                                   source buffer-size)))
+                            (declare (type deoxybyte-gzip::vector-index num-read))
+                            (when (plusp num-read)
+                              (setf zlib-ffi::next-in in
+                                    zlib-ffi::avail-in num-read))))
+                        zlib-ffi::avail-in)
+                      (write-from-zs ()
+                        (let ((fullp (zerop zlib-ffi::avail-out))
+                              (output-bytes (- buffer-size zlib-ffi::avail-out)))
+                          (unless (zerop output-bytes)
+                            (funcall output-fn out-buffer dest output-bytes)
+                            (setf zlib-ffi::next-out out
+                                  zlib-ffi::avail-out buffer-size))
+                          fullp))) ; Was the output buffer full on writing?
+                 (setf zlib-ffi::next-out out
+                       zlib-ffi::avail-out buffer-size)
+                 (loop
+                    for num-read = (read-from-zs)
+                    while (plusp num-read)
+                    do (let ((flush (if (= buffer-size num-read)
+                                        zlib-ffi:+z-no-flush+
+                                        zlib-ffi::+z-sync-flush+)))
+                         (loop
+                            with out-full = t
+                            while out-full
+                            do (let ((x (funcall op-fn zs flush)))
+                                 (when (= zlib-ffi:+z-stream-error+ x)
+                                   (deoxybyte-gzip::z-error x))
+                                 (setf out-full (write-from-zs)))))
+                    finally (progn
+                              (return (values zlib-ffi::total-in zlib-ffi::total-out)))))))))))

--- a/extensions.lisp
+++ b/extensions.lisp
@@ -4,14 +4,42 @@
 
 (in-package #:hunchensocket)
 
+(defmethod initialize-instance :after ((acceptor websocket-acceptor) &key)
+  "Validate the :extension-data argument"
+  (let ((extension-data (websocket-acceptor-extensions acceptor)))
+    (when extension-data
+      (handler-case 
+          (mapcar (lambda (sublist)
+                    (assert (and (eq :extension (first sublist))
+                                 (eq :headers (third sublist))
+                                 (eq :parameters (fifth sublist))))
+                    (check-type (fourth sublist) list)
+                    (check-type (sixth sublist) list))
+                  extension-data)
+        (error (condition)
+          (error "The extension-data argument list ~a is malformed.~&Error: ~s"
+                 extension-data condition))))))
+
+(defmethod format-extension-headers ((acceptor websocket-acceptor))
+  (when-let (extension-data (websocket-acceptor-extensions acceptor))
+    (str:join "; " (loop for sublist in extension-data
+                         append (fourth sublist)))))
+
+(defmethod initialize-extensions ((acceptor websocket-acceptor))
+  "Initialize extensions specified for this acceptor so they are ready
+to be passed to a client instance."
+  (let ((extension-data (websocket-acceptor-extensions acceptor)))
+    (mapcar (lambda (sublist)
+              (format t "~a~&" sublist)
+              (apply #'make-instance (second sublist) (sixth sublist)))
+            extension-data)))
+
 (defclass websocket-extension ()
-  ((headers :initarg :headers :reader extension-headers
-            :documentation "List of necessary headers for the
-            initial handshake needed by the extension")
-   (frame-header-bits :initarg :frame-header-bits :reader extension-frame-data
-                      :documentation "Return the frame header bits
-                      necessary for the protocol extension."))
-  (:documentation "Base class for extensions to the websocket protocol."))
+  ()
+  (:documentation "Base class for extensions to the websocket protocol.
+Instances of this class will be created on HUNCHENSOCKET:CLIENT
+objects and take care of extension-specific processing on incoming and
+outgoing frames and/or messages."))
 
 (defgeneric process-send-message (extension message)
   (:documentation "Process an outgoing message"))
@@ -19,117 +47,54 @@
 (defgeneric process-receive-message (extension message)
   (:documentation "Process an incoming message"))
 
-(defun format-headers (headers)
-  "Concatenate extension header strings in the correct format"
-  (str:join "; " headers))
+(defgeneric process-send-frames (extension frames)
+  (:documentation "Process outgoing frames"))
+
+(defgeneric process-receive-frames (extension frames)
+  (:documentation "Process incoming frames"))
 
 (defclass permessage-deflate (websocket-extension)
-  ()
-  (:default-initargs :headers '("permessage-deflate")
-                     :frame-header-bits #x04))
+  ((inflate-stream :initform (make-instance 'persistent-z-stream :operation :inflate)
+                   :reader pmd-inflate-stream)
+   (deflate-stream :initform (make-instance 'persistent-z-stream :operation :deflate)
+     :reader pmd-deflate-stream)))
+
+(defun array-slice (vector start end)
+  "Slice an array by indices"
+  (let ((end (cond ((eq end :end)
+                    (length vector))
+                   ((minusp end)
+                    (+ (length vector) end))
+                   (:else end))))
+    (make-array (- end start)
+                :element-type (array-element-type vector)
+                :displaced-to vector
+                :displaced-index-offset start)))
+
+(defmethod process-receive-frames ((ext permessage-deflate) frames)
+  "Decompress received frames, if the frame header bit is set"
+  (with-accessors ((opcode frame-opcode)
+                   (ext-data frame-extension-data)) (car frames)
+    (let* ((msg-bytes (apply #'concatenate '(vector (unsigned-byte 8))
+                             (mapcar #'frame-data frames)))
+           (maybe-processed (if (= ext-data #x04)
+                                (with-input-from-sequence
+                                    (in (concatenate '(vector (unsigned-byte 8))
+                                                     msg-bytes #(#x00 #x00 #xff #xff)))
+                                  (with-output-to-sequence (out)
+                                    (stream-operation (pmd-inflate-stream ext) in out)))
+                                msg-bytes)))
+      (cond ((= opcode +text-frame+)
+             (utf-8-bytes-to-string maybe-processed))
+            ((= opcode +binary-frame+)
+             maybe-processed)
+            (:else
+             (websocket-error 1002 "Client sent unknown opcode ~a" opcode))))))
 
 (defmethod process-send-message ((ext permessage-deflate) message-bytes)
-  (declare (ignore ext))
-  (compress-bytes message-bytes))
-
-(defmethod process-receive-message ((ext permessage-deflate) message-bytes)
-  (declare (ignore ext))
-  (decompress-bytes message-bytes))
-
-(defun compress-bytes (bytes)
-  ;; Normally, Z_SYNC_FLUSH would be used to append an empty deflate
-  ;; block. But according to the spec (7.2.3.4), we can use deflate
-  ;; blocks with the BFINAL bit set to 1, and append 0x00 to allow
-  ;; decompression by the same method as with Z_SYNC_FLUSH output.
-  ;; I'm using this method because I couldn't find a way of getting
-  ;; the Z_SYNC_FLUSH behaviour with any of the CL deflate libraries.
-  (concatenate '(vector (unsigned-byte 8))
-               (salza2:compress-data bytes 'salza2:deflate-compressor)
-               #(#x00)))
-
-(defun decompress-bytes (bytes)
-  ;; If the BFINAL bit in the deflate header is set to 0 the decompression
-  ;; will fail, so set it if necessary
-  (setf (ldb (byte 1 0)
-             (aref bytes 0))
-        #x01)
-  ;; Now do the actual decompression
-  (chipz:decompress nil *dstate*
-                    ;; The decompression method specified in RFC7692
-                    (concatenate '(vector (unsigned-byte 8))
-                                 bytes #(#x00 #x00 #xff #xff))))
-
-;; (defun send-message (resource client message &key (type :text))
-;;   "TODO documentation"
-;;   (let* ((extension     (resource-extension resource))
-;;          (message-bytes (ecase type
-;;                           (:text   (flexi-streams:string-to-octets message :external-format :utf-8))
-;;                           (:binary message)))
-;;          (frame-type    (ecase type
-;;                           (:text +text-frame+)
-;;                           (:binary +binary-frame+)))
-;;          (maybe-processed-message (if extension
-;;                                       (process-send-message extension message-bytes)
-;;                                       message)))
-;;     (with-slots (write-lock output-stream) client
-;;       (with-lock-held (write-lock)
-;;         (write-frame output-stream
-;;                      frame-type
-;;                      maybe-processed-message
-;;                      (if extension
-;;                          (extension-frame-data extension)
-;;                          #x00))))))
-
-(defparameter *z-deflate-stream* (deoxybyte-gzip::z-stream-open :deflate :suppress-header t :gzip-format nil))
-(defparameter *z-inflate-stream* (deoxybyte-gzip::z-stream-open :inflate :suppress-header t :gzip-format nil))
-
-(defun persistent-z-stream-operation (zs operation source dest input-fn output-fn buffer-size)
-  "Like deoxybyte:z-stream-operation, but called on an external
-z-stream so the compression / decompression algorithm state can be
-maintained between messages. Uses Z_SYNC_FLUSH rather than Z_FINISH as in the original function."
-  (let ((op-fn (ecase operation
-                 (:inflate #'zlib-ffi:%inflate)
-                 (:deflate #'zlib-ffi:%deflate)))
-        (in-buffer  (zlib-ffi::make-shareable-byte-vector buffer-size))
-        (out-buffer (zlib-ffi::make-shareable-byte-vector buffer-size)))
-    (unwind-protect
-         (cffi:with-foreign-slots ((zlib-ffi::avail-in zlib-ffi::next-in
-                                    zlib-ffi::avail-out zlib-ffi::next-out 
-                                    zlib-ffi::total-in zlib-ffi::total-out)
-                                   zs zlib-ffi::z-stream)
-           (cffi:with-pointer-to-vector-data (in in-buffer)
-             (cffi:with-pointer-to-vector-data (out out-buffer)
-               (flet ((read-from-zs ()
-                        (when (zerop zlib-ffi::avail-in)
-                          (let ((num-read (funcall input-fn in-buffer
-                                                   source buffer-size)))
-                            (declare (type deoxybyte-gzip::vector-index num-read))
-                            (when (plusp num-read)
-                              (setf zlib-ffi::next-in in
-                                    zlib-ffi::avail-in num-read))))
-                        zlib-ffi::avail-in)
-                      (write-from-zs ()
-                        (let ((fullp (zerop zlib-ffi::avail-out))
-                              (output-bytes (- buffer-size zlib-ffi::avail-out)))
-                          (unless (zerop output-bytes)
-                            (funcall output-fn out-buffer dest output-bytes)
-                            (setf zlib-ffi::next-out out
-                                  zlib-ffi::avail-out buffer-size))
-                          fullp))) ; Was the output buffer full on writing?
-                 (setf zlib-ffi::next-out out
-                       zlib-ffi::avail-out buffer-size)
-                 (loop
-                    for num-read = (read-from-zs)
-                    while (plusp num-read)
-                    do (let ((flush (if (= buffer-size num-read)
-                                        zlib-ffi:+z-no-flush+
-                                        zlib-ffi::+z-sync-flush+)))
-                         (loop
-                            with out-full = t
-                            while out-full
-                            do (let ((x (funcall op-fn zs flush)))
-                                 (when (= zlib-ffi:+z-stream-error+ x)
-                                   (deoxybyte-gzip::z-error x))
-                                 (setf out-full (write-from-zs)))))
-                    finally (progn
-                              (return (values zlib-ffi::total-in zlib-ffi::total-out)))))))))))
+  "Compress an outgoing message, following the procedure in RFC7692"
+  (array-slice (with-input-from-sequence (in message-bytes)
+                 (with-output-to-sequence (out)
+                   (stream-operation (pmd-deflate-stream ext)
+                                     in out :flush-type zlib-ffi::+z-sync-flush+)))
+               0 -4))

--- a/hunchensocket.asd
+++ b/hunchensocket.asd
@@ -11,11 +11,17 @@
                :trivial-utf-8
                :trivial-backtrace
                :bordeaux-threads
-               :cl-fad)
+               :cl-fad
+               :deoxybyte-gzip
+               :cffi
+               :chipz
+               :salza2
+               :str)
   :serial t
   :components
   ((:file "package")
-   (:file "hunchensocket")))
+   (:file "hunchensocket")
+   (:file "extensions")))
 
 (asdf:defsystem :hunchensocket-tests
     :description "Tests for Hunchensoket"

--- a/hunchensocket.asd
+++ b/hunchensocket.asd
@@ -14,17 +14,17 @@
                :cl-fad
                :deoxybyte-gzip
                :cffi
-               :chipz
-               :salza2
+               :trivial-garbage
                :str)
   :serial t
   :components
   ((:file "package")
    (:file "hunchensocket")
+   (:file "compression")
    (:file "extensions")))
 
 (asdf:defsystem :hunchensocket-tests
-    :description "Tests for Hunchensoket"
+    :description "Tests for Hunchensocket"
   :version #.(with-open-file (f "VERSION") (string (read f)))
   :depends-on (:fiasco
                :hunchensocket)

--- a/package.lisp
+++ b/package.lisp
@@ -5,6 +5,9 @@
   (:import-from :chunga :read-char*)
   (:import-from :trivial-backtrace :print-backtrace)
   (:import-from :hunchentoot :log-message*)
+  (:import-from #:compression
+                #:persistent-z-stream
+                #:stream-operation)
   (:export
    ;; acceptor classes
    #:websocket-acceptor
@@ -75,4 +78,6 @@
   (:import-from #:flexi-streams
                 #:with-input-from-sequence
                 #:with-output-to-sequence
-                #:string-to-octets))
+                #:string-to-octets)
+  (:export #:persistent-z-stream
+           #:stream-operation))

--- a/package.lisp
+++ b/package.lisp
@@ -37,6 +37,42 @@
    #:send-text-message
    #:send-binary-message))
 
-
-
-
+(cl:defpackage #:compression
+  (:use #:common-lisp)
+  (:import-from #:zlib-ffi
+                #:%inflate
+                #:%deflate
+                #:avail-in
+                #:avail-out
+                #:next-in
+                #:next-out
+                #:total-in
+                #:total-out
+                #:z-stream
+                #:make-shareable-byte-vector
+                #:+z-no-flush+
+                #:+z-finish+
+                #:+z-sync-flush+
+                #:+z-stream-error+
+                #:+z-data-error+)
+  (:import-from #:deoxybyte-gzip
+                #:z-stream-open
+                #:z-stream-close
+                #:fill-from-stream
+                #:empty-to-stream
+                #:+default-zlib-buffer-size+
+                #:vector-index
+                #:z-error
+                #:zlib-error
+                #:errno-of
+                #:fill-from-stream
+                #:empty-to-stream)
+  (:import-from #:trivial-garbage
+                #:finalize)
+  (:import-from #:cffi
+                #:with-foreign-slots
+                #:with-pointer-to-vector-data)
+  (:import-from #:flexi-streams
+                #:with-input-from-sequence
+                #:with-output-to-sequence
+                #:string-to-octets))


### PR DESCRIPTION
Hi, I've been working on support for permessage-deflate in hunchensocket. I'm submitting this PR so you can comment on what I've done so far and see if you think anything needs to be done differently. I've tested on Chrome and basic permessage-deflate works. I'm planning to add support for the other Sec-websocket-extension parameters in the RFC too e.g. max_window_bits. I've added 3 dependencies: the deoxybyte-gzip zlib cffi wrapper (I couldn't get flushing and sliding window maintenance to work with pure CL deflate implementations), trivial-garbage for implementation independent cleanup of the Zlib foreign data structures, and str because I'm lazy (this could be removed).

I tried to implement the extension framework in a generic way so it can support both non-standard extensions (Chrome allows Gzip compression) and user-defined extensions, like logging frames and messages in a human readable way

Chur

Isaac