### PR TITLE
Don't reset write-lock

### DIFF
--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -175,8 +175,7 @@ format control and arguments."
       (bt:with-lock-held (lock)
         (with-slots (write-lock) client
           (bt:with-lock-held (write-lock)
-            (setq clients (remove client clients)))
-          (setq write-lock nil)))
+            (setq clients (remove client clients)))))
       (client-disconnected resource client))))
 
 (defmacro with-new-client-for-resource ((client-sym &key input-stream
@@ -511,7 +510,7 @@ payloads."
           #+lispworks
           (setf (stream:stream-read-timeout stream) timeout
                 (stream:stream-write-timeout stream) timeout)
-          
+
           (catch 'websocket-done
             (handler-bind ((error #'(lambda (e)
                                       (maybe-invoke-debugger e)


### PR DESCRIPTION
Setting write-lock to nil, will mean that following requests will fail in a very cryptic way.
For instance, if I close the browser tab, the connection gets closed. But I have a thread that's still writing stuff to the websocket. Ideally, I'd like to get a socket error, not an error about the lock being nil.

I have a few more pull requests coming up. Not having a reliable lock, also makes it hard to write logic for the multithreading edge cases.