### PR TITLE
Export the ping functionality

### DIFF
--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -104,6 +104,9 @@
   (send-frame client +binary-frame+
               message))
 
+(defun send-ping (client &optional (message #()))
+  (send-frame client +ping+ message))
+
 (defun close-connection (client &key (data nil data-supplied-p)
                                      (status 1000)
                                      (reason "Normal close"))
@@ -511,7 +514,7 @@ payloads."
           #+lispworks
           (setf (stream:stream-read-timeout stream) timeout
                 (stream:stream-write-timeout stream) timeout)
-          
+
           (catch 'websocket-done
             (handler-bind ((error #'(lambda (e)
                                       (maybe-invoke-debugger e)

--- a/package.lisp
+++ b/package.lisp
@@ -24,19 +24,16 @@
 
    ;; resource accessors
    #:clients
-   
+
    ;; status updates
    ;;
    #:client-connected
    #:client-disconnected
-   
+
    ;; receiving and sending messages
-   ;; 
+   ;;
    #:binary-message-received
    #:text-message-received
+   #:send-ping
    #:send-text-message
    #:send-binary-message))
-
-
-
-


### PR DESCRIPTION
I'm using ping as a keep-alive mechanism. I think my nginx reverse proxy kills the connection if I don't keep sending keep-alive pings.