### PR TITLE
Replace ironclad dependency with sha1

### DIFF
--- a/hunchensocket.asd
+++ b/hunchensocket.asd
@@ -5,7 +5,8 @@
   :version #.(with-open-file (f "VERSION") (string (read f)))
   :depends-on (:hunchentoot
                :alexandria
-               :ironclad
+               :base64
+               :sha1
                :flexi-streams
                :chunga
                :trivial-utf-8

--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -537,11 +537,8 @@ non-locally with an error instead."
                    (concatenate 'string (header-in :sec-websocket-key request)
                                 "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")))
              (setf (header-out :sec-websocket-accept reply)
-                   (base64:usb8-array-to-base64-string
-                    (ironclad:digest-sequence
-                     'ironclad:sha1
-                     (ironclad:ascii-string-to-byte-array
-                      sec-websocket-key+magic))))
+                   (sha1:sha1-base64 sec-websocket-key+magic
+                                     #'base64:string-to-base64-string))
              (setf (header-out :sec-websocket-origin reply)
                    (header-in :origin request))
              (setf (header-out :sec-websocket-location reply)

--- a/package.lisp
+++ b/package.lisp
@@ -1,7 +1,6 @@
 (cl:defpackage :hunchensocket
   (:use :cl :alexandria :hunchentoot :cl-ppcre :alexandria
    :flexi-streams :trivial-utf-8 :bordeaux-threads)
-  (:import-from :ironclad :digest-sequence)
   (:import-from :chunga :read-char*)
   (:import-from :trivial-backtrace :print-backtrace)
   (:import-from :hunchentoot :log-message*)


### PR DESCRIPTION
Ironclad is a meaty dependency. This system takes the longest time on my
computer to compile my web application, and I've read comments online
that it adds ~19MB RAM usage in a lisp image. Hunchensocket is
currently using ironclad to produce SHA1 digests. A single-purpose
library can fill this need instead.

This change switches the dependency from ironclad:digest-sequence to
sha1:sha1-base64. It also promotes cl-base64 as a direct dependency,
since it's already directly referenced in the source code.