### PR TITLE
Use cl-base64 over base64

### DIFF
--- a/hunchensocket.asd
+++ b/hunchensocket.asd
@@ -5,7 +5,7 @@
   :version #.(with-open-file (f "VERSION") (string (read f)))
   :depends-on (:hunchentoot
                :alexandria
-               :base64
+               :cl-base64
                :sha1
                :flexi-streams
                :chunga


### PR DESCRIPTION
My previous PR #39 listed the wrong base64 system, which causes a package conflict in Quicklisp. This commit fixes the issue to use cl-base64 (the system that hunchentoot depends on) over base64 (a separate system altogether).